### PR TITLE
ATF-2: Switch the advice based feed propagation to event based

### DIFF
--- a/api/src/main/java/org/openmrs/module/atomfeed/AtomfeedActivator.java
+++ b/api/src/main/java/org/openmrs/module/atomfeed/AtomfeedActivator.java
@@ -15,9 +15,9 @@ import org.slf4j.LoggerFactory;
 /**
  * This class contains the logic that is run every time this module is either started or shutdown
  */
-public class AtomfeedmoduleActivator extends BaseModuleActivator {
+public class AtomfeedActivator extends BaseModuleActivator {
 	
-	private static final Logger LOGGER = LoggerFactory.getLogger(AtomfeedmoduleActivator.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(AtomfeedActivator.class);
 	
 	/**
 	 * @see #started()

--- a/api/src/main/java/org/openmrs/module/atomfeed/AtomfeedConfig.java
+++ b/api/src/main/java/org/openmrs/module/atomfeed/AtomfeedConfig.java
@@ -6,10 +6,15 @@
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */
-package org.openmrs.module.atomfeed.api;
+package org.openmrs.module.atomfeed;
 
-import org.openmrs.api.OpenmrsService;
+import org.springframework.stereotype.Component;
 
-public interface AtomfeedmoduleService extends OpenmrsService {
+/**
+ * Contains module's config.
+ */
+@Component("atomfeed.AtomfeedConfig")
+public class AtomfeedConfig {
 	
+	public static final String MODULE_PRIVILEGE = "Atomfeed module Privilege";
 }

--- a/api/src/main/java/org/openmrs/module/atomfeed/api/AtomfeedService.java
+++ b/api/src/main/java/org/openmrs/module/atomfeed/api/AtomfeedService.java
@@ -6,15 +6,10 @@
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */
-package org.openmrs.module.atomfeed;
+package org.openmrs.module.atomfeed.api;
 
-import org.springframework.stereotype.Component;
+import org.openmrs.api.OpenmrsService;
 
-/**
- * Contains module's config.
- */
-@Component("atomfeed.AtomfeedmoduleConfig")
-public class AtomfeedmoduleConfig {
+public interface AtomfeedService extends OpenmrsService {
 	
-	public static final String MODULE_PRIVILEGE = "Atomfeed module Privilege";
 }

--- a/api/src/main/java/org/openmrs/module/atomfeed/api/db/EventAction.java
+++ b/api/src/main/java/org/openmrs/module/atomfeed/api/db/EventAction.java
@@ -1,0 +1,13 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.atomfeed.api.db;
+
+public enum EventAction {
+	CREATED, UPDATED, RETIRED, UNRETIRED, VOIDED, UNVOIDED, DELETED
+}

--- a/api/src/main/java/org/openmrs/module/atomfeed/api/db/EventManager.java
+++ b/api/src/main/java/org/openmrs/module/atomfeed/api/db/EventManager.java
@@ -1,0 +1,28 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.atomfeed.api.db;
+
+import org.openmrs.OpenmrsObject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class EventManager {
+	
+	protected static final Logger LOGGER = LoggerFactory.getLogger(EventManager.class);
+	
+	public void serveEvent(OpenmrsObject openmrsObject, EventAction eventAction) {
+		Class<?> openmrsObjectClass = openmrsObject.getClass();
+		LOGGER.info("Called serveEvent method. Parameters: openmrsObject=" + openmrsObjectClass.getName() + ", eventAction="
+		        + eventAction.name());
+	}
+}

--- a/api/src/main/java/org/openmrs/module/atomfeed/api/db/EventManager.java
+++ b/api/src/main/java/org/openmrs/module/atomfeed/api/db/EventManager.java
@@ -12,7 +12,6 @@ import org.openmrs.OpenmrsObject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.springframework.stereotype.Component;
 
 @Component

--- a/api/src/main/java/org/openmrs/module/atomfeed/api/db/hibernate/HibernateEventInterceptor.java
+++ b/api/src/main/java/org/openmrs/module/atomfeed/api/db/hibernate/HibernateEventInterceptor.java
@@ -285,4 +285,32 @@ public class HibernateEventInterceptor extends EmptyInterceptor {
 			unvoidedObjects.remove();
 		}
 	}
+
+	public static void setInserts(ThreadLocal<Stack<HashSet<OpenmrsObject>>> inserts) {
+		HibernateEventInterceptor.inserts = inserts;
+	}
+
+	public static void setUpdates(ThreadLocal<Stack<HashSet<OpenmrsObject>>> updates) {
+		HibernateEventInterceptor.updates = updates;
+	}
+
+	public static void setDeletes(ThreadLocal<Stack<HashSet<OpenmrsObject>>> deletes) {
+		HibernateEventInterceptor.deletes = deletes;
+	}
+
+	public static void setRetiredObjects(ThreadLocal<Stack<HashSet<OpenmrsObject>>> retiredObjects) {
+		HibernateEventInterceptor.retiredObjects = retiredObjects;
+	}
+
+	public static void setUnretiredObjects(ThreadLocal<Stack<HashSet<OpenmrsObject>>> unretiredObjects) {
+		HibernateEventInterceptor.unretiredObjects = unretiredObjects;
+	}
+
+	public static void setVoidedObjects(ThreadLocal<Stack<HashSet<OpenmrsObject>>> voidedObjects) {
+		HibernateEventInterceptor.voidedObjects = voidedObjects;
+	}
+
+	public static void setUnvoidedObjects(ThreadLocal<Stack<HashSet<OpenmrsObject>>> unvoidedObjects) {
+		HibernateEventInterceptor.unvoidedObjects = unvoidedObjects;
+	}
 }

--- a/api/src/main/java/org/openmrs/module/atomfeed/api/db/hibernate/HibernateEventInterceptor.java
+++ b/api/src/main/java/org/openmrs/module/atomfeed/api/db/hibernate/HibernateEventInterceptor.java
@@ -1,0 +1,275 @@
+package org.openmrs.module.atomfeed.api.db.hibernate;
+
+import java.io.Serializable;
+import java.lang.reflect.Method;
+
+import java.util.HashSet;
+import java.util.Stack;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.hibernate.CallbackException;
+import org.hibernate.EmptyInterceptor;
+import org.hibernate.HibernateException;
+import org.hibernate.Interceptor;
+import org.hibernate.Transaction;
+import org.hibernate.type.Type;
+
+import org.openmrs.OpenmrsObject;
+import org.openmrs.Retireable;
+import org.openmrs.Voidable;
+import org.openmrs.api.context.Context;
+
+import org.springframework.stereotype.Component;
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * A hibernate {@link Interceptor} implementation, intercepts any database inserts, updates and
+ * deletes in a single hibernate session and fires the necessary events. Any changes/inserts/deletes
+ * made to the DB that are not made through the application won't be detected by the module. We use
+ * a Stack here to handle any nested transactions that may occur within a single thread
+ */
+@Component
+public class HibernateEventInterceptor extends EmptyInterceptor {
+	
+	private static final long serialVersionUID = 1L;
+	
+	protected final Log log = LogFactory.getLog(HibernateEventInterceptor.class);
+	
+	private ThreadLocal<Stack<HashSet<OpenmrsObject>>> inserts = new ThreadLocal<Stack<HashSet<OpenmrsObject>>>();
+	
+	private ThreadLocal<Stack<HashSet<OpenmrsObject>>> updates = new ThreadLocal<Stack<HashSet<OpenmrsObject>>>();
+	
+	private ThreadLocal<Stack<HashSet<OpenmrsObject>>> deletes = new ThreadLocal<Stack<HashSet<OpenmrsObject>>>();
+	
+	private ThreadLocal<Stack<HashSet<OpenmrsObject>>> retiredObjects = new ThreadLocal<Stack<HashSet<OpenmrsObject>>>();
+	
+	private ThreadLocal<Stack<HashSet<OpenmrsObject>>> unretiredObjects = new ThreadLocal<Stack<HashSet<OpenmrsObject>>>();
+	
+	private ThreadLocal<Stack<HashSet<OpenmrsObject>>> voidedObjects = new ThreadLocal<Stack<HashSet<OpenmrsObject>>>();
+	
+	private ThreadLocal<Stack<HashSet<OpenmrsObject>>> unvoidedObjects = new ThreadLocal<Stack<HashSet<OpenmrsObject>>>();
+	
+	/**
+	 * @see EmptyInterceptor#afterTransactionBegin(Transaction)
+	 */
+	@Override
+	public void afterTransactionBegin(Transaction tx) {
+		
+		initializeStackIfNecessary();
+		
+		inserts.get().push(new HashSet<OpenmrsObject>());
+		updates.get().push(new HashSet<OpenmrsObject>());
+		deletes.get().push(new HashSet<OpenmrsObject>());
+		retiredObjects.get().push(new HashSet<OpenmrsObject>());
+		unretiredObjects.get().push(new HashSet<OpenmrsObject>());
+		voidedObjects.get().push(new HashSet<OpenmrsObject>());
+		unvoidedObjects.get().push(new HashSet<OpenmrsObject>());
+	}
+	
+	/**
+	 * @see EmptyInterceptor#onSave(Object, Serializable, Object[], String[], Type[])
+	 */
+	@Override
+	public boolean onSave(Object entity, Serializable id, Object[] state, String[] propertyNames, Type[] types) {
+		if (entity instanceof OpenmrsObject) {
+			inserts.get().peek().add((OpenmrsObject) entity);
+		}
+		
+		//tells hibernate that there are no changes made here that
+		//need to be propagated to the persistent object and DB
+		return false;
+	}
+	
+	/**
+	 * @see EmptyInterceptor#onFlushDirty(Object, Serializable, Object[], Object[], String[],
+	 *      Type[])
+	 */
+	@Override
+	public boolean onFlushDirty(Object entity, Serializable id, Object[] currentState, Object[] previousState,
+								String[] propertyNames, Type[] types) {
+		
+		if (entity instanceof OpenmrsObject) {
+			OpenmrsObject object = (OpenmrsObject) entity;
+			updates.get().peek().add(object);
+			//Fire events for retired/unretired and voided/unvoided objects
+			if (entity instanceof Retireable || entity instanceof Voidable) {
+				for (int i = 0; i < propertyNames.length; i++) {
+					String auditableProperty = (entity instanceof Retireable) ? "retired" : "voided";
+					if (auditableProperty.equals(propertyNames[i])) {
+						boolean previousValue = false;
+						if (previousState != null && previousState[i] != null) {
+							previousValue = Boolean.valueOf(previousState[i].toString());
+						}
+						
+						boolean currentValue = false;
+						if (currentState != null && currentState[i] != null) {
+							currentValue = Boolean.valueOf(currentState[i].toString());
+						}
+						
+						if (previousValue != currentValue) {
+							if ("retired".equals(auditableProperty)) {
+								if (previousValue) {
+									unretiredObjects.get().peek().add(object);
+								} else {
+									retiredObjects.get().peek().add(object);
+								}
+							} else {
+								if (previousValue) {
+									unvoidedObjects.get().peek().add(object);
+								} else {
+									voidedObjects.get().peek().add(object);
+								}
+							}
+						}
+						
+						break;
+					}
+				}
+			}
+		}
+		
+		return false;
+	}
+	
+	/**
+	 * @see EmptyInterceptor#onDelete(Object, Serializable, Object[], String[], Type[])
+	 */
+	@Override
+	public void onDelete(Object entity, Serializable id, Object[] state, String[] propertyNames, Type[] types) {
+		if (entity instanceof OpenmrsObject) {
+			deletes.get().peek().add((OpenmrsObject) entity);
+		}
+	}
+	
+	/**
+	 * @see EmptyInterceptor#onCollectionUpdate(Object, Serializable)
+	 */
+	@Override
+	public void onCollectionUpdate(Object collection, Serializable key) throws CallbackException {
+		if (collection != null) {
+			//If a collection element has been added/removed, fire an update event for the parent entity
+			Object owningObject = getOwner(collection);
+			if (owningObject instanceof OpenmrsObject) {
+				updates.get().peek().add((OpenmrsObject) owningObject);
+			}
+		}
+	}
+	
+	/**
+	 * Gets the owning object of a persistent collection
+	 *
+	 * @param collection the persistent collection
+	 * @return the owning object
+	 */
+	private Object getOwner(Object collection) {
+		Class<?> pCollClass;
+		try {
+			pCollClass = Context.loadClass("org.hibernate.collection.PersistentCollection");
+		} catch (ClassNotFoundException oe) {
+			//We are running against openmrs core 2.0 or later where it's a later hibernate version
+			try {
+				pCollClass = Context.loadClass("org.hibernate.collection.spi.PersistentCollection");
+			} catch (ClassNotFoundException ie) {
+				throw new HibernateException(ie);
+			}
+		}
+		
+		Method method = ReflectionUtils.findMethod(pCollClass, "getOwner");
+		
+		return ReflectionUtils.invokeMethod(method, collection);
+	}
+	
+	/**
+	 * @see EmptyInterceptor#afterTransactionCompletion(Transaction)
+	 */
+	@Override
+	public void afterTransactionCompletion(Transaction tx) {
+		
+		try {
+			if (tx.wasCommitted()) {
+				for (OpenmrsObject delete : deletes.get().peek()) {
+					// TODO: add action
+				}
+				for (OpenmrsObject insert : inserts.get().peek()) {
+					// TODO: add action
+				}
+				for (OpenmrsObject update : updates.get().peek()) {
+					// TODO: add action
+				}
+				for (OpenmrsObject retired : retiredObjects.get().peek()) {
+					// TODO: add action
+				}
+				for (OpenmrsObject unretired : unretiredObjects.get().peek()) {
+					// TODO: add action
+				}
+				for (OpenmrsObject voided : voidedObjects.get().peek()) {
+					// TODO: add action
+				}
+				for (OpenmrsObject unvoided : unvoidedObjects.get().peek()) {
+					// TODO: add action
+				}
+			}
+		} finally {
+			//cleanup
+			inserts.get().pop();
+			updates.get().pop();
+			deletes.get().pop();
+			retiredObjects.get().pop();
+			unretiredObjects.get().pop();
+			voidedObjects.get().pop();
+			unvoidedObjects.get().pop();
+			
+			removeStackIfEmpty();
+		}
+	}
+	
+	private void initializeStackIfNecessary() {
+		if (inserts.get() == null) {
+			inserts.set(new Stack<HashSet<OpenmrsObject>>());
+		}
+		if (updates.get() == null) {
+			updates.set(new Stack<HashSet<OpenmrsObject>>());
+		}
+		if (deletes.get() == null) {
+			deletes.set(new Stack<HashSet<OpenmrsObject>>());
+		}
+		if (retiredObjects.get() == null) {
+			retiredObjects.set(new Stack<HashSet<OpenmrsObject>>());
+		}
+		if (unretiredObjects.get() == null) {
+			unretiredObjects.set(new Stack<HashSet<OpenmrsObject>>());
+		}
+		if (voidedObjects.get() == null) {
+			voidedObjects.set(new Stack<HashSet<OpenmrsObject>>());
+		}
+		if (unvoidedObjects.get() == null) {
+			unvoidedObjects.set(new Stack<HashSet<OpenmrsObject>>());
+		}
+	}
+	
+	private void removeStackIfEmpty() {
+		if (inserts.get().empty()) {
+			inserts.remove();
+		}
+		if (updates.get().empty()) {
+			updates.remove();
+		}
+		if (deletes.get().empty()) {
+			deletes.remove();
+		}
+		if (retiredObjects.get().empty()) {
+			retiredObjects.remove();
+		}
+		if (unretiredObjects.get().empty()) {
+			unretiredObjects.remove();
+		}
+		if (voidedObjects.get().empty()) {
+			voidedObjects.remove();
+		}
+		if (unvoidedObjects.get().empty()) {
+			unvoidedObjects.remove();
+		}
+	}
+}

--- a/api/src/main/java/org/openmrs/module/atomfeed/api/db/hibernate/HibernateEventInterceptor.java
+++ b/api/src/main/java/org/openmrs/module/atomfeed/api/db/hibernate/HibernateEventInterceptor.java
@@ -1,3 +1,11 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.atomfeed.api.db.hibernate;
 
 import java.io.Serializable;
@@ -16,9 +24,9 @@ import org.openmrs.OpenmrsObject;
 import org.openmrs.Retireable;
 import org.openmrs.Voidable;
 import org.openmrs.api.context.Context;
+import org.openmrs.module.atomfeed.api.db.EventAction;
+import org.openmrs.module.atomfeed.api.db.EventManager;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 import org.springframework.util.ReflectionUtils;
@@ -34,9 +42,7 @@ import org.springframework.util.ReflectionUtils;
 public class HibernateEventInterceptor extends EmptyInterceptor {
 	
 	private static final long serialVersionUID = 1L;
-	
-	protected static final Logger LOGGER = LoggerFactory.getLogger(HibernateEventInterceptor.class);
-	
+
 	private Stack<HashSet<OpenmrsObject>> inserts = new Stack<>();
 	
 	private Stack<HashSet<OpenmrsObject>> updates = new Stack<>();
@@ -190,34 +196,32 @@ public class HibernateEventInterceptor extends EmptyInterceptor {
 	 * @see EmptyInterceptor#afterTransactionCompletion(Transaction)
 	 */
 	@Override
-	@SuppressWarnings("PMD.EmptyTryBlock")
 	public void afterTransactionCompletion(Transaction tx) {
+		EventManager eventManager = Context.getService(EventManager.class);
 		try {
-			/*
 			if (tx.wasCommitted()) {
 				for (OpenmrsObject delete : deletes.peek()) {
-					// TODO: add action
+					eventManager.serveEvent(delete, EventAction.DELETED);
 				}
 				for (OpenmrsObject insert : inserts.peek()) {
-					// TODO: add action
+					eventManager.serveEvent(insert, EventAction.CREATED);
 				}
 				for (OpenmrsObject update : updates.peek()) {
-					// TODO: add action
+					eventManager.serveEvent(update, EventAction.UPDATED);
 				}
 				for (OpenmrsObject retired : retiredObjects.peek()) {
-					// TODO: add action
+					eventManager.serveEvent(retired, EventAction.RETIRED);
 				}
 				for (OpenmrsObject unretired : unretiredObjects.peek()) {
-					// TODO: add action
+					eventManager.serveEvent(unretired, EventAction.UNRETIRED);
 				}
 				for (OpenmrsObject voided : voidedObjects.peek()) {
-					// TODO: add action
+					eventManager.serveEvent(voided, EventAction.VOIDED);
 				}
 				for (OpenmrsObject unvoided : unvoidedObjects.peek()) {
-					// TODO: add action
+					eventManager.serveEvent(unvoided, EventAction.UNVOIDED);
 				}
 			}
-			*/
 		} finally {
 			//cleanup
 			inserts.pop();

--- a/api/src/main/java/org/openmrs/module/atomfeed/api/impl/AtomfeedServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/atomfeed/api/impl/AtomfeedServiceImpl.java
@@ -9,10 +9,10 @@
 package org.openmrs.module.atomfeed.api.impl;
 
 import org.openmrs.api.impl.BaseOpenmrsService;
-import org.openmrs.module.atomfeed.api.AtomfeedmoduleService;
+import org.openmrs.module.atomfeed.api.AtomfeedService;
 import org.springframework.stereotype.Component;
 
-@Component("atomfeed.AtomfeedmoduleService")
-public class AtomfeedmoduleServiceImpl extends BaseOpenmrsService implements AtomfeedmoduleService {
+@Component("atomfeed.AtomfeedService")
+public class AtomfeedServiceImpl extends BaseOpenmrsService implements AtomfeedService {
 	
 }

--- a/api/src/main/java/org/openmrs/module/atomfeed/api/model/FeedConfiguration.java
+++ b/api/src/main/java/org/openmrs/module/atomfeed/api/model/FeedConfiguration.java
@@ -11,54 +11,54 @@ package org.openmrs.module.atomfeed.api.model;
 import java.util.HashMap;
 
 public class FeedConfiguration {
-
-    private String openMrsClass;
-
-    private boolean enabled;
-
-    private String title;
-
-    private HashMap<String, String> linkTemplates;
-
-    private String feedWriter;
-
-    public String getOpenMrsClass() {
-        return openMrsClass;
-    }
-
-    public void setOpenMrsClass(String openMrsClass) {
-        this.openMrsClass = openMrsClass;
-    }
-
-    public boolean isEnabled() {
-        return enabled;
-    }
-
-    public void setEnabled(boolean enabled) {
-        this.enabled = enabled;
-    }
-
-    public String getTitle() {
-        return title;
-    }
-
-    public void setTitle(String title) {
-        this.title = title;
-    }
-
-    public HashMap<String, String> getLinkTemplates() {
-        return linkTemplates;
-    }
-
-    public void setLinkTemplates(HashMap<String, String> linkTemplates) {
-        this.linkTemplates = linkTemplates;
-    }
-
-    public String getFeedWriter() {
-        return feedWriter;
-    }
-
-    public void setFeedWriter(String feedWriter) {
-        this.feedWriter = feedWriter;
-    }
+	
+	private String openMrsClass;
+	
+	private boolean enabled;
+	
+	private String title;
+	
+	private HashMap<String, String> linkTemplates;
+	
+	private String feedWriter;
+	
+	public String getOpenMrsClass() {
+		return openMrsClass;
+	}
+	
+	public void setOpenMrsClass(String openMrsClass) {
+		this.openMrsClass = openMrsClass;
+	}
+	
+	public boolean isEnabled() {
+		return enabled;
+	}
+	
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+	
+	public String getTitle() {
+		return title;
+	}
+	
+	public void setTitle(String title) {
+		this.title = title;
+	}
+	
+	public HashMap<String, String> getLinkTemplates() {
+		return linkTemplates;
+	}
+	
+	public void setLinkTemplates(HashMap<String, String> linkTemplates) {
+		this.linkTemplates = linkTemplates;
+	}
+	
+	public String getFeedWriter() {
+		return feedWriter;
+	}
+	
+	public void setFeedWriter(String feedWriter) {
+		this.feedWriter = feedWriter;
+	}
 }

--- a/api/src/main/java/org/openmrs/module/atomfeed/api/utils/AtomfeedUtils.java
+++ b/api/src/main/java/org/openmrs/module/atomfeed/api/utils/AtomfeedUtils.java
@@ -34,7 +34,8 @@ public final class AtomfeedUtils {
 		ObjectMapper mapper = new ObjectMapper();
 		try {
 			return mapper.readValue(readResourceFile(resourcePath), FeedConfiguration.class);
-		} catch (IOException e) {
+		}
+		catch (IOException e) {
 			throw new AtomfeedIoException(e);
 		}
 	}

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -23,13 +23,13 @@
 
     <context:component-scan base-package="org.openmrs.module.atomfeed" />
 
-    <!-- Adds AtomfeedmoduleService to OpenMRS context so it can be accessed
-    calling Context.getService(AtomfeedmoduleService.class) -->
+    <!-- Adds AtomfeedService to OpenMRS context so it can be accessed
+    calling Context.getService(AtomfeedService.class) -->
     <bean parent="serviceContext">
         <property name="moduleService">
             <list>
-                <value>org.openmrs.module.atomfeed.api.AtomfeedmoduleService</value>
-                <ref bean="atomfeed.AtomfeedmoduleService" />
+                <value>org.openmrs.module.atomfeed.api.AtomfeedService</value>
+                <ref bean="atomfeed.AtomfeedService" />
             </list>
         </property>
     </bean>

--- a/api/src/test/java/org/openmrs/module/atomfeed/api/db/hibernate/HibernateEventInterceptorTest.java
+++ b/api/src/test/java/org/openmrs/module/atomfeed/api/db/hibernate/HibernateEventInterceptorTest.java
@@ -59,7 +59,7 @@ public class HibernateEventInterceptorTest extends BaseModuleContextSensitiveTes
 	}
 	
 	@Test
-	public void onSave_shouldSaveOpenmrsObject() {
+	public void onSave_shouldAddOpenmrsObjectToInsertSet() {
 		final OpenmrsObject expected = mock(OpenmrsObject.class);
 		hibernateEventInterceptor.afterTransactionBegin(null); // init structure
 		
@@ -68,7 +68,7 @@ public class HibernateEventInterceptorTest extends BaseModuleContextSensitiveTes
 	}
 	
 	@Test
-	public void onSave_shouldNotSaveNotOpenmrsObject() {
+	public void onSave_shouldNotAddNotOpenmrsObjectToInsertSet() {
 		final Object notOpenmrsObject = mock(Object.class);
 		hibernateEventInterceptor.afterTransactionBegin(null); // init structure
 		
@@ -81,9 +81,23 @@ public class HibernateEventInterceptorTest extends BaseModuleContextSensitiveTes
 	}
 	
 	@Test
-	public void onDelete() {
+	public void onDelete_shouldAddOpenmrsObjectToDeleteSet() {
+		final OpenmrsObject expected = mock(OpenmrsObject.class);
+		hibernateEventInterceptor.afterTransactionBegin(null); // init structure
+
+		hibernateEventInterceptor.onDelete(expected, null, null, null, null);
+		Assert.assertTrue(deletes.get().peek().contains(expected));
 	}
-	
+
+	@Test
+	public void onDelete_shouldNotAddNotOpenmrsObjectToDeleteSet() {
+		final Object notOpenmrsObject = mock(Object.class);
+		hibernateEventInterceptor.afterTransactionBegin(null); // init structure
+
+		hibernateEventInterceptor.onSave(notOpenmrsObject, null, null, null, null);
+		Assert.assertFalse(deletes.get().peek().contains(notOpenmrsObject));
+	}
+
 	@Test
 	public void onCollectionUpdate() {
 	}

--- a/api/src/test/java/org/openmrs/module/atomfeed/api/db/hibernate/HibernateEventInterceptorTest.java
+++ b/api/src/test/java/org/openmrs/module/atomfeed/api/db/hibernate/HibernateEventInterceptorTest.java
@@ -1,25 +1,38 @@
 package org.openmrs.module.atomfeed.api.db.hibernate;
 
+import org.hibernate.Transaction;
 import org.hibernate.collection.spi.PersistentCollection;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.openmrs.OpenmrsObject;
+import org.openmrs.module.atomfeed.api.db.EventAction;
+import org.openmrs.module.atomfeed.api.db.EventManager;
 
 import java.util.HashSet;
 import java.util.Stack;
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class HibernateEventInterceptorTest {
-
+	
 	@Mock
-	private final OpenmrsObject openmrsObject = mock(OpenmrsObject.class);
-
+	private EventManager eventManager;
+	
 	@Mock
-	private final Object notOpenmrsObject = mock(Object.class);
+	private OpenmrsObject openmrsObject;
+	
+	@Mock
+	private Object notOpenmrsObject;
 	
 	private ThreadLocal<Stack<HashSet<OpenmrsObject>>> inserts;
 	
@@ -35,10 +48,12 @@ public class HibernateEventInterceptorTest {
 	
 	private ThreadLocal<Stack<HashSet<OpenmrsObject>>> unvoidedObjects;
 	
+	@InjectMocks
 	private HibernateEventInterceptor hibernateEventInterceptor = new HibernateEventInterceptor();
 	
 	@Before
 	public void setup() {
+		MockitoAnnotations.initMocks(this);
 		initVariables();
 	}
 	
@@ -88,47 +103,107 @@ public class HibernateEventInterceptorTest {
 	@Test
 	public void onDelete_shouldAddOpenmrsObjectToDeleteSet() {
 		hibernateEventInterceptor.afterTransactionBegin(null); // init structure
-
+		
 		hibernateEventInterceptor.onDelete(openmrsObject, null, null, null, null);
 		Assert.assertTrue(deletes.get().peek().contains(openmrsObject));
 	}
-
+	
 	@Test
 	public void onDelete_shouldNotAddNotOpenmrsObjectToDeleteSet() {
 		hibernateEventInterceptor.afterTransactionBegin(null); // init structure
-
+		
 		hibernateEventInterceptor.onSave(notOpenmrsObject, null, null, null, null);
 		Assert.assertFalse(deletes.get().peek().contains(notOpenmrsObject));
 	}
-
+	
 	@Test
 	public void onCollectionUpdate_shouldAddOwnerOfUpdatedCollectionToUpdateSet() {
 		final OpenmrsObject expectedCollectionOwner = openmrsObject;
-
+		
 		final PersistentCollection updatedCollection = mock(PersistentCollection.class);
 		when(updatedCollection.getOwner()).thenReturn(expectedCollectionOwner);
-
+		
 		hibernateEventInterceptor.afterTransactionBegin(null); // init structure
-
+		
 		hibernateEventInterceptor.onCollectionUpdate(updatedCollection, null);
 		Assert.assertTrue(updates.get().peek().contains(expectedCollectionOwner));
 	}
-
+	
 	@Test
 	public void onCollectionUpdate_shouldNotAddOwnerOfUpdatedCollectionWhenTheyAreNotOpenmrsObject() {
 		final Object collectionOwner = notOpenmrsObject;
-
+		
 		final PersistentCollection updatedCollection = mock(PersistentCollection.class);
 		when(updatedCollection.getOwner()).thenReturn(collectionOwner);
-
+		
 		hibernateEventInterceptor.afterTransactionBegin(null); // init structure
-
+		
 		hibernateEventInterceptor.onCollectionUpdate(updatedCollection, null);
 		Assert.assertFalse(updates.get().peek().contains(collectionOwner));
 	}
 	
 	@Test
-	public void afterTransactionCompletion() {
+	public void afterTransactionCompletion_shouldCallServeEventMethodInEventManagerOnEveryObjectInStack() {
+		hibernateEventInterceptor.afterTransactionBegin(null); // init structure
+		
+		addOpenmrsObjectToAllSets();
+		
+		final Transaction transaction = mock(Transaction.class);
+		when(transaction.wasCommitted()).thenReturn(true);
+		
+		hibernateEventInterceptor.afterTransactionCompletion(transaction);
+		
+		verify(eventManager, times(1)).serveEvent(eq(openmrsObject), eq(EventAction.CREATED));
+		verify(eventManager, times(1)).serveEvent(eq(openmrsObject), eq(EventAction.DELETED));
+		verify(eventManager, times(1)).serveEvent(eq(openmrsObject), eq(EventAction.UPDATED));
+		verify(eventManager, times(1)).serveEvent(eq(openmrsObject), eq(EventAction.RETIRED));
+		verify(eventManager, times(1)).serveEvent(eq(openmrsObject), eq(EventAction.UNRETIRED));
+		verify(eventManager, times(1)).serveEvent(eq(openmrsObject), eq(EventAction.VOIDED));
+		verify(eventManager, times(1)).serveEvent(eq(openmrsObject), eq(EventAction.UNVOIDED));
+	}
+	
+	@Test
+	public void afterTransactionCompletion_shouldNotServeEventsWhenTransationWasNotCommited() {
+		hibernateEventInterceptor.afterTransactionBegin(null); // init structure
+		
+		addOpenmrsObjectToAllSets();
+		
+		final Transaction transaction = mock(Transaction.class);
+		when(transaction.wasCommitted()).thenReturn(false);
+		
+		hibernateEventInterceptor.afterTransactionCompletion(transaction);
+		
+		verify(eventManager, never()).serveEvent(any(), any());
+	}
+	
+	@Test
+	public void afterTransactionCompletion_shouldCleanupSetsAtTheEndOfMethod() {
+		hibernateEventInterceptor.afterTransactionBegin(null); // init structure
+		
+		addOpenmrsObjectToAllSets();
+		
+		final Transaction transaction = mock(Transaction.class);
+		when(transaction.wasCommitted()).thenReturn(false);
+		
+		hibernateEventInterceptor.afterTransactionCompletion(transaction);
+		
+		Assert.assertNull(inserts.get());
+		Assert.assertNull(inserts.get());
+		Assert.assertNull(inserts.get());
+		Assert.assertNull(inserts.get());
+		Assert.assertNull(inserts.get());
+		Assert.assertNull(inserts.get());
+		Assert.assertNull(inserts.get());
+	}
+	
+	private void addOpenmrsObjectToAllSets() {
+		inserts.get().peek().add(openmrsObject);
+		deletes.get().peek().add(openmrsObject);
+		updates.get().peek().add(openmrsObject);
+		retiredObjects.get().peek().add(openmrsObject);
+		unretiredObjects.get().peek().add(openmrsObject);
+		voidedObjects.get().peek().add(openmrsObject);
+		unvoidedObjects.get().peek().add(openmrsObject);
 	}
 	
 	private void initVariables() {

--- a/api/src/test/java/org/openmrs/module/atomfeed/api/db/hibernate/HibernateEventInterceptorTest.java
+++ b/api/src/test/java/org/openmrs/module/atomfeed/api/db/hibernate/HibernateEventInterceptorTest.java
@@ -1,32 +1,99 @@
 package org.openmrs.module.atomfeed.api.db.hibernate;
 
+import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
+import org.openmrs.OpenmrsObject;
+import org.openmrs.module.atomfeed.api.db.EventManager;
 import org.openmrs.test.BaseModuleContextSensitiveTest;
 
+import java.util.HashSet;
+import java.util.Stack;
+
 public class HibernateEventInterceptorTest extends BaseModuleContextSensitiveTest {
+	
+	// @Mock
+	// private EventManager eventManager;
+	
+	private ThreadLocal<Stack<HashSet<OpenmrsObject>>> inserts;
+	
+	private ThreadLocal<Stack<HashSet<OpenmrsObject>>> updates;
+	
+	private ThreadLocal<Stack<HashSet<OpenmrsObject>>> deletes;
+	
+	private ThreadLocal<Stack<HashSet<OpenmrsObject>>> retiredObjects;
+	
+	private ThreadLocal<Stack<HashSet<OpenmrsObject>>> unretiredObjects;
+	
+	private ThreadLocal<Stack<HashSet<OpenmrsObject>>> voidedObjects;
+	
+	private ThreadLocal<Stack<HashSet<OpenmrsObject>>> unvoidedObjects;
 
-    @Test
-    public void afterTransactionBegin() throws Exception {
+	private HibernateEventInterceptor hibernateEventInterceptor = new HibernateEventInterceptor();
+	
+	@Before
+	public void setup() {
+		initVariables();
+	}
+	
+	@Test
+	public void afterTransactionBegin_shouldInitStackWithOneEmptyHashSet() {
+		hibernateEventInterceptor.afterTransactionBegin(null);
+
+		Assert.assertEquals(1, inserts.get().size());
+		Assert.assertEquals(1, updates.get().size());
+		Assert.assertEquals(1, deletes.get().size());
+		Assert.assertEquals(1, retiredObjects.get().size());
+		Assert.assertEquals(1, unretiredObjects.get().size());
+		Assert.assertEquals(1, voidedObjects.get().size());
+		Assert.assertEquals(1, unvoidedObjects.get().size());
+
+		Assert.assertEquals(0, inserts.get().peek().size());
+		Assert.assertEquals(0, updates.get().peek().size());
+		Assert.assertEquals(0, deletes.get().peek().size());
+		Assert.assertEquals(0, retiredObjects.get().peek().size());
+		Assert.assertEquals(0, unretiredObjects.get().peek().size());
+		Assert.assertEquals(0, voidedObjects.get().peek().size());
+		Assert.assertEquals(0, unvoidedObjects.get().peek().size());
+	}
+	
+	@Test
+	public void onSave() {
+
+	}
+	
+	@Test
+	public void onFlushDirty() {
+	}
+	
+	@Test
+	public void onDelete() {
+	}
+	
+	@Test
+	public void onCollectionUpdate() {
+	}
+	
+	@Test
+	public void afterTransactionCompletion() {
+	}
+	
+	private void initVariables() {
+        inserts = new ThreadLocal<>();
+        updates = new ThreadLocal<>();
+        deletes = new ThreadLocal<>();
+        retiredObjects = new ThreadLocal<>();
+        unretiredObjects = new ThreadLocal<>();
+        voidedObjects = new ThreadLocal<>();
+        unvoidedObjects = new ThreadLocal<>();
+
+		HibernateEventInterceptor.setInserts(inserts);
+		HibernateEventInterceptor.setUpdates(updates);
+		HibernateEventInterceptor.setDeletes(deletes);
+		HibernateEventInterceptor.setRetiredObjects(retiredObjects);
+		HibernateEventInterceptor.setUnretiredObjects(unretiredObjects);
+		HibernateEventInterceptor.setVoidedObjects(voidedObjects);
+		HibernateEventInterceptor.setUnvoidedObjects(unvoidedObjects);
     }
-
-    @Test
-    public void onSave() throws Exception {
-    }
-
-    @Test
-    public void onFlushDirty() throws Exception {
-    }
-
-    @Test
-    public void onDelete() throws Exception {
-    }
-
-    @Test
-    public void onCollectionUpdate() throws Exception {
-    }
-
-    @Test
-    public void afterTransactionCompletion() throws Exception {
-    }
-
 }

--- a/api/src/test/java/org/openmrs/module/atomfeed/api/db/hibernate/HibernateEventInterceptorTest.java
+++ b/api/src/test/java/org/openmrs/module/atomfeed/api/db/hibernate/HibernateEventInterceptorTest.java
@@ -3,13 +3,13 @@ package org.openmrs.module.atomfeed.api.db.hibernate;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mock;
 import org.openmrs.OpenmrsObject;
-import org.openmrs.module.atomfeed.api.db.EventManager;
 import org.openmrs.test.BaseModuleContextSensitiveTest;
 
 import java.util.HashSet;
 import java.util.Stack;
+
+import static org.mockito.Mockito.mock;
 
 public class HibernateEventInterceptorTest extends BaseModuleContextSensitiveTest {
 	
@@ -29,7 +29,7 @@ public class HibernateEventInterceptorTest extends BaseModuleContextSensitiveTes
 	private ThreadLocal<Stack<HashSet<OpenmrsObject>>> voidedObjects;
 	
 	private ThreadLocal<Stack<HashSet<OpenmrsObject>>> unvoidedObjects;
-
+	
 	private HibernateEventInterceptor hibernateEventInterceptor = new HibernateEventInterceptor();
 	
 	@Before
@@ -40,7 +40,7 @@ public class HibernateEventInterceptorTest extends BaseModuleContextSensitiveTes
 	@Test
 	public void afterTransactionBegin_shouldInitStackWithOneEmptyHashSet() {
 		hibernateEventInterceptor.afterTransactionBegin(null);
-
+		
 		Assert.assertEquals(1, inserts.get().size());
 		Assert.assertEquals(1, updates.get().size());
 		Assert.assertEquals(1, deletes.get().size());
@@ -48,7 +48,7 @@ public class HibernateEventInterceptorTest extends BaseModuleContextSensitiveTes
 		Assert.assertEquals(1, unretiredObjects.get().size());
 		Assert.assertEquals(1, voidedObjects.get().size());
 		Assert.assertEquals(1, unvoidedObjects.get().size());
-
+		
 		Assert.assertEquals(0, inserts.get().peek().size());
 		Assert.assertEquals(0, updates.get().peek().size());
 		Assert.assertEquals(0, deletes.get().peek().size());
@@ -59,8 +59,21 @@ public class HibernateEventInterceptorTest extends BaseModuleContextSensitiveTes
 	}
 	
 	@Test
-	public void onSave() {
-
+	public void onSave_shouldSaveOpenmrsObject() {
+		final OpenmrsObject expected = mock(OpenmrsObject.class);
+		hibernateEventInterceptor.afterTransactionBegin(null); // init structure
+		
+		hibernateEventInterceptor.onSave(expected, null, null, null, null);
+		Assert.assertTrue(inserts.get().peek().contains(expected));
+	}
+	
+	@Test
+	public void onSave_shouldNotSaveNotOpenmrsObject() {
+		final Object notOpenmrsObject = mock(Object.class);
+		hibernateEventInterceptor.afterTransactionBegin(null); // init structure
+		
+		hibernateEventInterceptor.onSave(notOpenmrsObject, null, null, null, null);
+		Assert.assertFalse(inserts.get().peek().contains(notOpenmrsObject));
 	}
 	
 	@Test

--- a/api/src/test/java/org/openmrs/module/atomfeed/api/db/hibernate/HibernateEventInterceptorTest.java
+++ b/api/src/test/java/org/openmrs/module/atomfeed/api/db/hibernate/HibernateEventInterceptorTest.java
@@ -1,0 +1,32 @@
+package org.openmrs.module.atomfeed.api.db.hibernate;
+
+import org.junit.Test;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
+
+public class HibernateEventInterceptorTest extends BaseModuleContextSensitiveTest {
+
+    @Test
+    public void afterTransactionBegin() throws Exception {
+    }
+
+    @Test
+    public void onSave() throws Exception {
+    }
+
+    @Test
+    public void onFlushDirty() throws Exception {
+    }
+
+    @Test
+    public void onDelete() throws Exception {
+    }
+
+    @Test
+    public void onCollectionUpdate() throws Exception {
+    }
+
+    @Test
+    public void afterTransactionCompletion() throws Exception {
+    }
+
+}

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -42,6 +42,7 @@
 		audits that should be suppressed.
 		http://checkstyle.sourceforge.net/config.html
 	-->
+	<module name="SuppressWarningsFilter"/>
 	<module name="SuppressionFilter">
 		<property name="file" value="checkstyle-suppressions.xml"/>
 	</module>
@@ -84,6 +85,7 @@
 	</module>
 
 	<module name="TreeWalker">
+		<module name="SuppressWarningsHolder"/>
 		<!-- Defines expected tab width for checks that require a tab width -->
 		<property name="tabWidth" value="4"/>
 

--- a/omod/src/main/java/org/openmrs/module/atomfeed/web/controller/AtomfeedController.java
+++ b/omod/src/main/java/org/openmrs/module/atomfeed/web/controller/AtomfeedController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
 @Controller
-public class AtomfeedmoduleController {
+public class AtomfeedController {
 	
 	/** Success form view name */
 	private static final String VIEW = "/module/atomfeed/atomfeed";

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -12,7 +12,7 @@
 			${project.parent.description}
 	</description>
 
-	<activator>org.openmrs.module.atomfeed.AtomfeedmoduleActivator</activator>
+	<activator>org.openmrs.module.atomfeed.AtomfeedActivator</activator>
 
 	<require_version>2.0.5</require_version>
 	

--- a/pom.xml
+++ b/pom.xml
@@ -29,9 +29,9 @@
 	</organization>
 
 	<scm>
-		<connection>scm:git:git@github.com:pkornowski/openmrs-module-atomfeed.git</connection>
-		<developerConnection>scm:git:git@github.com:pkornowski/openmrs-module-atomfeed.git</developerConnection>
-		<url>https://github.com/pkornowski/openmrs-module-atomfeed/</url>
+		<connection>scm:git:git@github.com:openmrs/openmrs-module-atomfeed.git</connection>
+		<developerConnection>scm:git:git@github.com:openmrs/openmrs-module-atomfeed.git</developerConnection>
+		<url>https://github.com/openmrs/openmrs-module-atomfeed/</url>
 	</scm>
 
 	<modules>


### PR DESCRIPTION
* create hibernate event interceptor which catches hibernate events [(based on this) ](https://github.com/openmrs/openmrs-module-event/blob/master/api/src/main/java/org/openmrs/event/api/db/hibernate/HibernateEventInterceptor.java )
* create simple manager that serve these events
* write appropriate tests

In addition to that I also:
* changed scm in pom.xml to OpenMRS repository
* corrected service names to more appropriate