### PR TITLE
Added missing columns in failed_events table

### DIFF
--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -94,4 +94,14 @@
             <column name="tags" type="varchar(255)"/>
         </createTable>
     </changeSet>
+
+    <changeSet author="SolDevelo" id="org.openmrs.module.atomfeed-2017-12-14-17:28">
+        <addColumn tableName="failed_events">
+            <column name="title" type="varchar(255)"/>
+            <column name="retries" type="int" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+            <column name="error_hash_code" type="int"/>
+        </addColumn>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
They are columns that are used [here](https://github.com/ICT4H/atomfeed/blob/5b2aaef200b7aca2cb8c29d51d70ae9117d1e9eb/atomfeed-client/src/main/java/org/ict4h/atomfeed/client/repository/jdbc/AllFailedEventsJdbcImpl.java#L164)