### PR TITLE
Set default valuie for date_created field event_records table.

### DIFF
--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -27,7 +27,7 @@
             <column name="uri" type="varchar(255)" />
             <column name="object" type="varchar(1000)" />
             <column name="category" type="varchar(255)" />
-            <column name="date_created" type="timestamp" />
+            <column name="date_created" type="timestamp" defaultValueDate="CURRENT_TIMESTAMP"/>
             <column name="tags" type="varchar(255)" />
         </createTable>
         <createTable tableName="event_records_queue">


### PR DESCRIPTION
I was not able to start AtomFeed module on MySQL 5.8.
This fixed the issue for me.